### PR TITLE
change to system2() to work with both mac and windows

### DIFF
--- a/R/edf2asc.R
+++ b/R/edf2asc.R
@@ -81,11 +81,11 @@ edf2asc <- function(edffiles) {
   info <- sessionInfo()
   
   for (ff in edffiles) {
-    if (grepl('mac', info$running, ignore.case = TRUE)) {
-      log <- system2(exe, args = paste(opts,ff), stdout = TRUE)
-    } else if (grepl('windows', info$running, ignore.case = TRUE)) {
+    if (grepl('mac|win', info$running, ignore.case = TRUE)) {
       ## see R function shQuote() for help building the command line string.
-      log <- system2(shQuote(exe), args = shQuote(paste(opts,ff)), stdout = TRUE)
+      log <- system2(shQuote(exe, type = "cmd2"), 
+                     args = shQuote(paste(opts,ff), type = "cmd2"), 
+                     stdout = TRUE)
     } else {
       stop("Only Mac OSX and Windows are supported currently.")
     }

--- a/R/edf2asc.R
+++ b/R/edf2asc.R
@@ -82,10 +82,10 @@ edf2asc <- function(edffiles) {
   
   for (ff in edffiles) {
     if (grepl('mac', info$running, ignore.case = TRUE)) {
-      log <- system(paste(exe, opts, ff), intern=TRUE) # should update this to system2()
+      log <- system2(exe, args = paste(opts,ff), stdout = TRUE)
     } else if (grepl('windows', info$running, ignore.case = TRUE)) {
       ## see R function shQuote() for help building the command line string.
-      log <- system(paste(shQuote(exe), opts, shQuote(ff)), intern=TRUE) # should update this to system2()
+      log <- system2(shQuote(exe), args = shQuote(paste(opts,ff)), stdout = TRUE)
     } else {
       stop("Only Mac OSX and Windows are supported currently.")
     }


### PR DESCRIPTION
It appears to me that using type = "cmd2" in shQuote() should make it work with both Mac and Windows. When I tested with my Mac, only type = "cmd2" would work, and based on the manual for shQuote(), "cmd2" is the one preferred for cmd.exe on Windows anyway. It might cause problem for Mac when there are double quotes in the file names, though. Perhaps we should check file names and ask the user to remove double quotes from file names?