### PR TITLE
add error messages for regdef2ias()

### DIFF
--- a/R/textRegions.R
+++ b/R/textRegions.R
@@ -250,6 +250,17 @@ regdef2ias <- function(fname) {
     yml <- paste(l[yml], collapse="\n")
     parms <- yaml::yaml.load(yml)
 
+    ## check if crucial parameters are in the yaml block
+    parms_check <- list(parms$margins$left,
+                        parms$regions$maxH,
+                        parms$regions$minH,
+                        parms$lines$baseline)
+    if (sum(sapply(parms_check, is.null, simplify = TRUE)) > 0) {
+      stop(paste("At least one of the following parameters are missing in the yaml block:",
+                 "margins: left, regions: maxH, regions: minH, lines: baselines",
+                 sep = "\n"))
+    }
+    
     ## get regdef block
     tstart <- max(yidx)+1
     tend <- length(l)
@@ -268,6 +279,11 @@ regdef2ias <- function(fname) {
     sep <- FDButils::series(which(tidx), minseries=1)
     text_line <- c(1, sep[,1]+sep[,3])
 
+    ## check if number of lines matches between yaml-block defined baselines and regdef-block text
+    if (length(parms$lines$baselines)!=length(text_line)) {
+      stop("The number of baselines (defined in the yaml block) and the number of lines in text do not match.")
+    }
+    
     ## set up ias data.frame to store regdef info
     ias <- data.frame()
 

--- a/inst/extdata/story01-regdef.txt
+++ b/inst/extdata/story01-regdef.txt
@@ -22,8 +22,6 @@ lines:
   - 576
   - 637
   - 698
-  - 763
-  - 824
 margins:
   top: 72		# distance from top of screen to top of 1st line of text in pixels
   left: 215		# distance from left edge of screen to left edge of 1st character in line of text, in pixels.

--- a/inst/extdata/story03-regdef.txt
+++ b/inst/extdata/story03-regdef.txt
@@ -25,7 +25,6 @@ lines:
   - 777
   - 838
   - 899
-  - 960
 margins:
   top: 72 		# distance from top of screen to top of 1st line of text in pixels
   left: 215		# distance from left edge of screen to left edge of 1st character in line of text, in pixels.


### PR DESCRIPTION
1. check if crucial parameters (margins: left, regions: maxH, regions:
minH, lines: baselines) are included in the yaml block
2. check if the number of baselines in the yaml block matches the number
of lines in the text